### PR TITLE
Fix autofocus #125

### DIFF
--- a/Graphics/AIGraphics/AIGraphics.csproj
+++ b/Graphics/AIGraphics/AIGraphics.csproj
@@ -35,12 +35,12 @@
       <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.0-beta2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="AIAPI, Version=1.12.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.AIAPI.1.12.0\lib\net46\AIAPI.dll</HintPath>
+    <Reference Include="AIAPI, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.AIAPI.1.12.2\lib\net46\AIAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="AI_ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExtensibleSaveFormat.AIGirl.15.0.0\lib\net46\AI_ExtensibleSaveFormat.dll</HintPath>
+      <HintPath>..\packages\ExtensibleSaveFormat.AIGirl.15.1.2\lib\net46\AI_ExtensibleSaveFormat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Graphics/AIGraphics/packages.config
+++ b/Graphics/AIGraphics/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExtensibleSaveFormat.AIGirl" version="15.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.AIGirl" version="15.1.2" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.Cinemachine" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.MessagePack" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
@@ -15,5 +15,5 @@
   <package id="IllusionLibs.AIGirl.UnityEngine.UI" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx" version="5.0.1.1" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx.Harmony" version="2.0.0-beta2" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionModdingAPI.AIAPI" version="1.12.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionModdingAPI.AIAPI" version="1.12.2" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Graphics/HS2Graphics/Graphics.cs
+++ b/Graphics/HS2Graphics/Graphics.cs
@@ -1,9 +1,7 @@
 ﻿using BepInEx;
 using KKAPI;
-using KKAPI.Studio.SaveLoad;
 using System.Collections;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
 namespace Graphics
@@ -11,7 +9,7 @@ namespace Graphics
     public partial class Graphics : BaseUnityPlugin
     {
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
-        {   
+        {
             StartCoroutine(InitializeLight(scene));
             CullingMaskExtensions.RefreshLayers();
         }
@@ -49,7 +47,7 @@ namespace Graphics
                 case GameMode.Studio:
                     return KKAPI.Studio.StudioAPI.StudioLoaded;
                 case GameMode.MainGame:
-                    return null != GameObject.Find("MapScene") && SceneManager.GetActiveScene().isLoaded && null != Camera.main; //KKAPI doesn't provide an api for in game check 
+                    return "MyRoom" == SceneManager.GetActiveScene().name && SceneManager.GetActiveScene().isLoaded && null != Camera.main; //HS2API doesn't provide an api for in game check 
                 default:
                     return false;
             }

--- a/Graphics/HS2Graphics/HS2Graphics.csproj
+++ b/Graphics/HS2Graphics/HS2Graphics.csproj
@@ -55,12 +55,12 @@
       <HintPath>..\packages\IllusionLibs.HoneySelect2.Cinemachine.2018.4.11\lib\net46\Cinemachine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="HS2API, Version=1.12.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.HS2API.1.12.0\lib\net46\HS2API.dll</HintPath>
+    <Reference Include="HS2API, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.HS2API.1.12.2\lib\net46\HS2API.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HS2_ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ExtensibleSaveFormat.HoneySelect2.15.0.0\lib\net46\HS2_ExtensibleSaveFormat.dll</HintPath>
+      <HintPath>..\packages\ExtensibleSaveFormat.HoneySelect2.15.1.2\lib\net46\HS2_ExtensibleSaveFormat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IL, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Graphics/HS2Graphics/packages.config
+++ b/Graphics/HS2Graphics/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ExtensibleSaveFormat.HoneySelect2" version="15.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.HoneySelect2" version="15.1.2" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx" version="5.0.1.1" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx.Harmony" version="2.0.0-beta2" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.HoneySelect2.Assembly-CSharp" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
@@ -16,5 +16,5 @@
   <package id="IllusionLibs.HoneySelect2.UnityEngine.PhysicsModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.HoneySelect2.UnityEngine.TextRenderingModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.HoneySelect2.UnityEngine.UI" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionModdingAPI.HS2API" version="1.12.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionModdingAPI.HS2API" version="1.12.2" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Graphics/Shared/CharaController.cs
+++ b/Graphics/Shared/CharaController.cs
@@ -1,0 +1,47 @@
+﻿using KKAPI;
+using KKAPI.Chara;
+using System.Collections;
+using UnityEngine;
+
+namespace Graphics
+{
+    internal class CharaController : CharaCustomFunctionController
+    {
+        protected override void OnCardBeingSaved(GameMode currentGameMode)
+        {
+            //no action
+        }
+
+        protected override void OnReload(GameMode currentGameMode)
+        {
+            StartCoroutine(LoadColliders(currentGameMode));
+        }
+
+        private IEnumerator LoadColliders(GameMode currentGameMode)
+        {
+            if (GameMode.Maker == currentGameMode || GameMode.Studio == currentGameMode)
+                ChaControl.LoadHitObject();
+
+            yield return new WaitUntil(() => null != ChaControl.objHitBody && null != ChaControl.objHitHead);
+            ForceColliderUpdate(false);
+        }
+
+        internal void ForceColliderUpdate(bool force)
+        {
+            GameObject[] hitObjects = { ChaControl.objHitBody, ChaControl.objHitHead };
+            foreach (GameObject ho in hitObjects)
+            {
+                if (null == ho)
+                    return;
+
+                SkinnedCollisionHelper[] componentsInChildren = ho.GetComponentsInChildren<SkinnedCollisionHelper>(true);
+                foreach (SkinnedCollisionHelper skinnedCollisionHelper in componentsInChildren)
+                {
+                    skinnedCollisionHelper.gameObject.SetActive(true);
+                    skinnedCollisionHelper.forceUpdate = force;
+                    skinnedCollisionHelper.updateOncePerFrame = !force;
+                }
+            }
+        }
+    }
+}

--- a/Graphics/Shared/FocusPuller.cs
+++ b/Graphics/Shared/FocusPuller.cs
@@ -6,47 +6,43 @@ namespace Graphics
 {
     public class FocusPuller : MonoBehaviour
     {
-        private Graphics _parent;
         private float _velocity;
+        private float _speed = 6f;
         private Vector3 lastDoFPoint;
         private bool initialFrame;
         private GameObject _ftgo;
         private Transform _target;
-        public LayerMask hitLayer;
-        public float maxDistance;
+#if DEBUG
+        private LineDrawer lineDrawer;
+#endif
 
-        public Transform FocusTarget
-        {
-            get
-            {
-                if (!_target)
-                {
-                    _ftgo = new GameObject("FocusTarget");
-                    _target = _ftgo.transform;
-                }
-                return _target;
-            }
-            set => _target = value;
-        }
-
-        [SerializeField] private float _speed = 6f;
-        public float speed
+        internal LayerMask HitLayer { get; set; }
+        internal float MaxDistance { get; set; }
+        internal Vector3 TargetFocusPoint { get; private set; }
+        internal Vector3 TargetPosition { get => null != _target ? _target.position : Vector3.zero; }
+        internal Vector3 TransformPosition { get => null != _target ? transform.position : Vector3.zero; }
+        internal Vector3 HitPoint { get; private set; }
+        internal Vector3 RayOrigin { get; private set; }
+        internal float Speed
         {
             get => _speed;
-            set => _speed = Mathf.Max(0.01f, value);
+            set => _speed = Mathf.Max(MinSpeed, value);
         }
-
-        public void init(Graphics parent)
-        {
-            _parent = parent;
-            hitLayer = _parent.CameraSettings.MainCamera.cullingMask;
-            maxDistance = _parent.CameraSettings.MainCamera.farClipPlane;
-        }
+        internal static float MinSpeed = 1f;
+        internal static float MaxSpeed = 12f;
+        internal static string ColliderLayer = "H_MetaBallB";
+        internal static string DefaultLayer = "Default";
 
         private void Awake()
         {
-            Physics.queriesHitBackfaces = true;
-
+            _ftgo = new GameObject("FocusTarget");
+            _target = _ftgo.transform;
+            HitLayer = CullingMaskExtensions.LayerCullingShow(Graphics.Instance.CameraSettings.MainCamera.cullingMask, ColliderLayer);
+            HitLayer = CullingMaskExtensions.LayerCullingHide(HitLayer, DefaultLayer);
+            MaxDistance = Graphics.Instance.CameraSettings.MainCamera.farClipPlane;
+#if DEBUG
+            lineDrawer = new LineDrawer();
+#endif
         }
 
         private void OnEnable()
@@ -56,11 +52,13 @@ namespace Graphics
 
         private void OnValidate()
         {
-            speed = _speed;
+            Speed = _speed;
         }
 
-        private void LateUpdate()
+        private void OnPreRender()
         {
+            if (_target == null) return;
+
             if (initialFrame)
             {
                 initialFrame = false;
@@ -72,12 +70,12 @@ namespace Graphics
             }
 
             // Retrieve the current value.
-            float d1 = _parent.PostProcessingSettings.FocalDistance;//_controller.depthOfField.focusDistance;
-
-            //Debug.DrawLine(transform.position, _target.position, Color.green);
-
+            float d1 = Graphics.Instance.PostProcessingSettings.FocalDistance;
+#if DEBUG
+            lineDrawer.DrawLineInGameView(transform.position, _target.position, Color.green);
+#endif
             // Calculate the depth of the focus point.
-            float d2 = Vector3.Dot((FocusTarget?.position ?? new Vector3(Screen.width / 2, Screen.height / 2)) - transform.position, transform.forward);
+            float d2 = Vector3.Dot(_target.position - transform.position, transform.forward);
             if (d2 < 0.1f)
             {
                 d2 = 0.1f;
@@ -85,33 +83,122 @@ namespace Graphics
 
             // Damped-spring interpolation.
             float dt = Time.deltaTime;
-            float n1 = _velocity - (d1 - d2) * speed * speed * dt;
-            float n2 = 1 + speed * dt;
+            float n1 = _velocity - (d1 - d2) * Speed * Speed * dt;
+            float n2 = 1 + Speed * dt;
             _velocity = n1 / (n2 * n2);
             float d = d1 + _velocity * dt;
 
             // Apply the result.
-            _parent.PostProcessingSettings.FocalDistance = d;
+            Graphics.Instance.PostProcessingSettings.FocalDistance = d;
         }
 
         private void Focus(Vector3 PointOnScreen)
         {
+            TargetFocusPoint = PointOnScreen;
             // our ray
-            //var ray = transform.GetComponent<Camera>().ScreenPointToRay(PointOnScreen);
-            Ray ray = _parent.CameraSettings.MainCamera.ScreenPointToRay(PointOnScreen);
-            if (Physics.Raycast(ray, out RaycastHit hit, maxDistance, hitLayer))
+            var ray = transform.GetComponent<Camera>().ScreenPointToRay(PointOnScreen);
+            RayOrigin = ray.origin;
+#if DEBUG
+            lineDrawer.DrawLineInGameView(ray.origin, ray.direction * 100, Color.yellow);
+#endif
+            if (Physics.Raycast(ray, out RaycastHit hit, MaxDistance, HitLayer))
             {
-                //Debug.DrawLine(ray.origin, hit.point);
+                HitPoint = hit.point;
+#if DEBUG
+                lineDrawer.DrawLineInGameView(ray.origin, hit.point, Color.green);
+#endif
                 // do we have a new point?					
                 if (lastDoFPoint == hit.point)
                 {
                     return;
                 }
 
-                FocusTarget.position = hit.point;
+                _target.position = hit.point;
                 // asign the last hit
                 lastDoFPoint = hit.point;
             }
+            /*
+             * debug - Do any of the rays hit?
+             * RaycastHit[] results = new RaycastHit[10];            
+             
+            if (0 < Physics.RaycastNonAlloc(ray, results, MaxDistance))
+            {
+                foreach (var result in results)
+                {
+                    // Check for null since some array spots might be
+                    if (result.collider != null)
+                    {
+                        Graphics.Instance.Log.Log(BepInEx.Logging.LogLevel.All, "hit " + result.collider.gameObject.name);
+                    }
+                }
+            }
+            else
+            {
+                Graphics.Instance.Log.Log(BepInEx.Logging.LogLevel.All, "didn't hit");
+            }
+            */
         }
+#if DEBUG
+        public struct LineDrawer
+        {
+            private LineRenderer lineRenderer;
+            private float lineSize;
+
+            public LineDrawer(float lineSize = 0.2f)
+            {
+                GameObject lineObj = new GameObject("LineObj");
+                lineRenderer = lineObj.AddComponent<LineRenderer>();
+                //Particles/Additive
+                lineRenderer.material = new Material(Shader.Find("Hidden/Internal-Colored"));
+
+                this.lineSize = lineSize;
+            }
+
+            private void init(float lineSize = 0.2f)
+            {
+                if (lineRenderer == null)
+                {
+                    GameObject lineObj = new GameObject("LineObj");
+                    lineRenderer = lineObj.AddComponent<LineRenderer>();
+                    //Particles/Additive
+                    lineRenderer.material = new Material(Shader.Find("Hidden/Internal-Colored"));
+
+                    this.lineSize = lineSize;
+                }
+            }
+
+            //Draws lines through the provided vertices
+            public void DrawLineInGameView(Vector3 start, Vector3 end, Color color)
+            {
+                if (lineRenderer == null)
+                {
+                    init(0.2f);
+                }
+
+                //Set color
+                lineRenderer.startColor = color;
+                lineRenderer.endColor = color;
+
+                //Set width
+                lineRenderer.startWidth = lineSize;
+                lineRenderer.endWidth = lineSize;
+
+                //Set line count which is 2
+                lineRenderer.positionCount = 2;
+
+                //Set the postion of both two lines
+                lineRenderer.SetPosition(0, start);
+                lineRenderer.SetPosition(1, end);
+            }
+
+            public void Destroy()
+            {
+                if (lineRenderer != null)
+                {
+                    UnityEngine.Object.Destroy(lineRenderer.gameObject);
+                }
+            }
+        }
+#endif
     }
 }

--- a/Graphics/Shared/Graphics.cs
+++ b/Graphics/Shared/Graphics.cs
@@ -5,6 +5,7 @@ using Graphics.Patch;
 using Graphics.Settings;
 using Graphics.Textures;
 using KKAPI;
+using KKAPI.Chara;
 using KKAPI.Studio.SaveLoad;
 using System;
 using System.Collections;
@@ -41,10 +42,10 @@ namespace Graphics
         private bool _isLoaded = false;
         private CursorLockMode _previousCursorLockState;
         private bool _previousCursorVisible;
+#if AI
         private float _previousTimeScale;
-
+#endif 
         private SkyboxManager _skyboxManager;
-        private FocusPuller _focusPuller;
         private LightManager _lightManager;
         private PostProcessingManager _postProcessingManager;
         private PresetManager _presetManager;
@@ -88,6 +89,7 @@ namespace Graphics
 
         private void Awake()
         {
+            CharacterApi.RegisterExtraBehaviour<CharaController>(GUID);
             StudioSaveLoadApi.RegisterExtraBehaviour<SceneController>(GUID);
             SceneManager.sceneLoaded += OnSceneLoaded;
         }
@@ -120,10 +122,6 @@ namespace Graphics
             LocalizationManager.CurrentLanguage = ConfigLanguage.Value;
 
             _lightManager = new LightManager(this);
-
-            _focusPuller = Instance.GetOrAddComponent<FocusPuller>();
-            _focusPuller.init(this);
-            DontDestroyOnLoad(_focusPuller);
             _presetManager = new PresetManager(ConfigPresetPath.Value, this);
 
             yield return new WaitUntil(() => PCSSLight.LoadAssets());
@@ -136,7 +134,6 @@ namespace Graphics
         internal SkyboxManager SkyboxManager => _skyboxManager;
         internal PostProcessingManager PostProcessingManager => _postProcessingManager;
         internal LightManager LightManager => _lightManager;
-        internal FocusPuller FocusPuller => _focusPuller;
         internal PresetManager PresetManager => _presetManager;
 
         internal void OnGUI()
@@ -195,21 +192,24 @@ namespace Graphics
                 {
                     if (value)
                     {
+#if AI
                         if (KKAPI.KoikatuAPI.GetCurrentGameMode() == KKAPI.GameMode.MainGame)
                         {
                             _previousTimeScale = Time.timeScale;
                             Time.timeScale = 0;
                         }
+#endif
                         _previousCursorLockState = Cursor.lockState;
                         _previousCursorVisible = Cursor.visible;
                     }
                     else
                     {
+#if AI
                         if (KKAPI.KoikatuAPI.GetCurrentGameMode() == KKAPI.GameMode.MainGame)
                         {
                             Time.timeScale = _previousTimeScale;
                         }
-
+#endif
                         if (!_previousCursorVisible || _previousCursorLockState != CursorLockMode.None)
                         {
                             Cursor.lockState = _previousCursorLockState;

--- a/Graphics/Shared/Inspector/GUIUtility.cs
+++ b/Graphics/Shared/Inspector/GUIUtility.cs
@@ -457,11 +457,11 @@ namespace Graphics.Inspector
             GUILayout.Label(label, GUILayout.ExpandWidth(false));
             GUILayout.Label("", GUILayout.Width(GUIStyles.labelWidth - GUI.skin.label.CalcSize(new GUIContent(label)).x));
             GUILayout.Label("X", GUILayout.ExpandWidth(false));
-            float.TryParse(GUILayout.TextField(size.x.ToString()), out float x);
+            float.TryParse(GUILayout.TextField(size.x.ToString("N2")), out float x);
             GUILayout.Label("Y", GUILayout.ExpandWidth(false));
-            float.TryParse(GUILayout.TextField(size.y.ToString()), out float y);
+            float.TryParse(GUILayout.TextField(size.y.ToString("N2")), out float y);
             GUILayout.Label("Z", GUILayout.ExpandWidth(false));
-            float.TryParse(GUILayout.TextField(size.z.ToString()), out float z);
+            float.TryParse(GUILayout.TextField(size.z.ToString("N2")), out float z);
             Vector3 newSize = size;
             if (x != size.x || y != size.y || z != size.z)
             {

--- a/Graphics/Shared/Inspector/Inspector.cs
+++ b/Graphics/Shared/Inspector/Inspector.cs
@@ -79,7 +79,7 @@ namespace Graphics.Inspector
                     LightInspector.Draw(Parent.Settings, Parent.LightManager, Parent.Settings.ShowAdvancedSettings);
                     break;
                 case Tab.PostProcessing:
-                    PostProcessingInspector.Draw(Parent.PostProcessingSettings, Parent.PostProcessingManager, Parent.FocusPuller, Parent.Settings.ShowAdvancedSettings);
+                    PostProcessingInspector.Draw(Parent.PostProcessingSettings, Parent.PostProcessingManager, Parent.Settings.ShowAdvancedSettings);
                     break;
                 case Tab.Presets:
                     PresetInspector.Draw(Parent.PresetManager);

--- a/Graphics/Shared/Resources/localization.japanese.txt
+++ b/Graphics/Shared/Resources/localization.japanese.txt
@@ -16,7 +16,7 @@ Baked,ベイク
 bias,バイアス
 Blend Distance,ブレンド距離
 Bloom,ブルーム
-Blue,緑
+Blue,青
 Bounces,バウンス
 Box Offset,オフセット
 Box Projection,ボックスプロジェクション
@@ -69,7 +69,7 @@ FromQualitySettings,品質設定から
 gain,ゲイン
 gamma,ガンマ
 Grain,グレイン
-Green,青
+Green,緑
 hard only,ハード
 HDR,高度なレンダリング機能 (HDR)
 high,高

--- a/Graphics/Shared/Setting/PostProcessingParameters.cs
+++ b/Graphics/Shared/Setting/PostProcessingParameters.cs
@@ -1,4 +1,5 @@
-﻿using MessagePack;
+﻿using Graphics.Inspector;
+using MessagePack;
 using UnityEngine;
 #if AI
 using static AmplifyOcclusionBase;
@@ -435,9 +436,7 @@ namespace Graphics.Settings
         {
             if (layer != null)
             {
-                if (Graphics.Instance.FocusPuller != null)
-                    focusPuller = Graphics.Instance.FocusPuller.enabled;
-
+                focusPuller = PostProcessingInspector.AutoFocusEnabled;
                 enabled = new BoolValue(layer.enabled);
                 focusDistance = new FloatValue(layer.focusDistance);
                 aperture = new FloatValue(layer.aperture);
@@ -450,9 +449,7 @@ namespace Graphics.Settings
         {
             if (layer != null)
             {
-                if (Graphics.Instance.FocusPuller != null)
-                    Graphics.Instance.FocusPuller.enabled = this.focusPuller;
-
+                PostProcessingInspector.AutoFocusEnabled = focusPuller;
                 enabled.Fill(layer.enabled);
                 layer.active = layer.enabled.value;
                 focusDistance.Fill(layer.focusDistance);

--- a/Graphics/Shared/Shared.projitems
+++ b/Graphics/Shared/Shared.projitems
@@ -86,6 +86,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CharaController.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Alloy\AlloyPropertyAttributes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Alloy\AlloyUtils.cs" />
@@ -163,9 +164,6 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Resources\toolbar button act.png" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Resources\toolbar button on.png" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Resources\toolbar button.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)MessagePack\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Resources\pcss" />


### PR DESCRIPTION
* update to BepInEx v5.1
* update to KKAPI 1.12.3
* fix scene name for HS2 in game check so Graphics can load directly in game without going to maker first
* clean up focuspuller implementation
* load character colliders in maker and studio so they can be used for raycast detection for autofocus